### PR TITLE
Simplify vertex shader and drawing directives

### DIFF
--- a/shaders/fullscreen.wgsl
+++ b/shaders/fullscreen.wgsl
@@ -10,8 +10,7 @@ var<private> gl_Position: vec4<f32>;
 fn main1() {
     let e3: u32 = gl_VertexIndex;
     texture_coordinates.x = select(0.0, 2.0, (e3 == u32(2)));
-    let e11: u32 = gl_VertexIndex;
-    texture_coordinates.y = select(0.0, 2.0, (e11 == u32(1)));
+    texture_coordinates.y = select(0.0, 2.0, (e3 == u32(1)));
     let e19: vec2<f32> = texture_coordinates;
     gl_Position = vec4<f32>(((e19 * vec2<f32>(2.0, -(2.0))) + vec2<f32>(-(1.0), 1.0)), 1.0, 1.0);
     return;

--- a/src/glow_post_process.rs
+++ b/src/glow_post_process.rs
@@ -273,7 +273,7 @@ impl GlowPostProcess {
             });
             pass.set_pipeline(&self.copy_glowing_pass.pipeline);
             pass.set_bind_group(0, &self.copy_glowing_pass.bind_group, &[]);
-            pass.draw(0..6, 0..1);
+            pass.draw(0..3, 0..1);
         }
         {
             let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
@@ -290,7 +290,7 @@ impl GlowPostProcess {
             });
             pass.set_pipeline(&self.vertical_blur_pass.pipeline);
             pass.set_bind_group(0, &self.vertical_blur_pass.bind_group, &[]);
-            pass.draw(0..6, 0..1);
+            pass.draw(0..3, 0..1);
         }
         {
             let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
@@ -307,7 +307,7 @@ impl GlowPostProcess {
             });
             pass.set_pipeline(&self.horizontal_blur_pass.pipeline);
             pass.set_bind_group(0, &self.horizontal_blur_pass.bind_group, &[]);
-            pass.draw(0..6, 0..1);
+            pass.draw(0..3, 0..1);
         }
         {
             let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
@@ -324,7 +324,7 @@ impl GlowPostProcess {
             });
             pass.set_pipeline(&self.combine_pass.pipeline);
             pass.set_bind_group(0, &self.combine_pass.bind_group, &[]);
-            pass.draw(0..6, 0..1);
+            pass.draw(0..3, 0..1);
         }
     }
 }


### PR DESCRIPTION
I'm not super experienced with shader code, so apologies if these changes are incorrect. I noticed some details of the vertex shading code that seemed off, namely some redundant variables and repeated vertices. As far as I can tell, reducing the number of vertices to 4 has no impact on the glow effect.

To be honest, I don't know if I fully understand what the vertex shader is doing. As far as I can tell, it takes only the vertex index (previously 0..6, now 0..3) as input, and produces vertices representing the full screen quad. But it doesn't seem that texture_coordinates will ever refer to (2, 2), so I'm not sure how to interpret the vertices being produced. I would appreciate an explanation of this, and I would be happy to make fixes if necessary.