### PR TITLE
Randomize left and right particle motion

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -48,34 +48,33 @@ pub fn move_liquid(sandbox: &mut Sandbox, x: usize, y: usize) -> (usize, usize) 
             sandbox[x][y + 1] = sandbox[x][y].take();
             return (x, y + 1);
         }
-        // Else move 1 down and left if able
-        if x != 0 {
-            if sandbox[x - 1][y + 1].is_none() && sandbox[x - 1][y].is_none() {
-                sandbox[x - 1][y + 1] = sandbox[x][y].take();
-                return (x - 1, y + 1);
-            }
+        // Else, move 1 down and randomly left or right if able
+        let mut avail_diag_x = Vec::new();
+        if x != 0 && sandbox[x - 1][y + 1].is_none() && sandbox[x - 1][y].is_none() {
+            avail_diag_x.push(x - 1);
         }
-        // Else move 1 down and right if able
-        if x != SANDBOX_WIDTH - 1 {
-            if sandbox[x + 1][y + 1].is_none() && sandbox[x + 1][y].is_none() {
-                sandbox[x + 1][y + 1] = sandbox[x][y].take();
-                return (x + 1, y + 1);
-            }
+        if x != SANDBOX_WIDTH - 1 && sandbox[x + 1][y + 1].is_none() && sandbox[x + 1][y].is_none()
+        {
+            avail_diag_x.push(x + 1);
         }
-    }
-    // Else move left if able
-    if x != 0 {
-        if sandbox[x - 1][y].is_none() {
-            sandbox[x - 1][y] = sandbox[x][y].take();
-            return (x - 1, y);
+        avail_diag_x.shuffle(&mut sandbox.rng);
+        if let Some(&diag_x) = avail_diag_x.get(0) {
+            sandbox[diag_x][y + 1] = sandbox[x][y].take();
+            return (diag_x, y + 1);
         }
     }
-    // Else move right if able
-    if x != SANDBOX_WIDTH - 1 {
-        if sandbox[x + 1][y].is_none() {
-            sandbox[x + 1][y] = sandbox[x][y].take();
-            return (x + 1, y);
-        }
+    // Else, move randomly left or right if able
+    let mut avail_side_x = Vec::new();
+    if x != 0 && sandbox[x - 1][y].is_none() {
+        avail_side_x.push(x - 1);
+    }
+    if x != SANDBOX_WIDTH - 1 && sandbox[x + 1][y].is_none() {
+        avail_side_x.push(x + 1);
+    }
+    avail_side_x.shuffle(&mut sandbox.rng);
+    if let Some(&side_x) = avail_side_x.get(0) {
+        sandbox[side_x][y] = sandbox[x][y].take();
+        return (side_x, y);
     }
     (x, y)
 }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -4,29 +4,31 @@ use rand::seq::SliceRandom;
 use rand::Rng;
 use std::ptr;
 
+/// Returns a random available neighbor of (x, y) if any.
+/// Searches x-1 and x+1 at a y-coordinate of y + y_offset
 fn rand_available_neighbor(
     sandbox: &mut Sandbox,
     x: usize,
     y: usize,
-    y_off: isize,
+    y_offset: isize,
 ) -> Option<(usize, usize)> {
     // Check whether the left and right paths to candidate cells are free
-    let left = x != 0
-        && (y_off == 0 || sandbox[x - 1][(y as isize + y_off) as usize].is_none())
+    let left_free = x != 0
+        && (y_offset == 0 || sandbox[x - 1][(y as isize + y_offset) as usize].is_none())
         && sandbox[x - 1][y].is_none();
-    let right = x != SANDBOX_WIDTH - 1
-        && (y_off == 0 || sandbox[x + 1][(y as isize + y_off) as usize].is_none())
+    let right_free = x != SANDBOX_WIDTH - 1
+        && (y_offset == 0 || sandbox[x + 1][(y as isize + y_offset) as usize].is_none())
         && sandbox[x + 1][y].is_none();
-    if left || right {
+    if left_free || right_free {
         // If both are free, pick one at random, else pick the free one
-        let diag_x = if left && right {
-            [x - 1, x + 1][sandbox.rng.gen::<bool>() as usize]
-        } else if left {
+        let diagonal_x = if left_free && right_free {
+            [x - 1, x + 1][sandbox.rng.gen_range(0..2)]
+        } else if left_free {
             x - 1
         } else {
             x + 1
         };
-        Some((diag_x, (y as isize + y_off) as usize))
+        Some((diagonal_x, (y as isize + y_offset) as usize))
     } else {
         None
     }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -22,19 +22,20 @@ pub fn move_powder(sandbox: &mut Sandbox, x: usize, y: usize) -> (usize, usize) 
             sandbox[x][y + 1] = sandbox[x][y].take();
             return (x, y + 1);
         }
-        // Else move 1 down and left if able
-        if x != 0 {
-            if sandbox[x - 1][y + 1].is_none() && sandbox[x - 1][y].is_none() {
-                sandbox[x - 1][y + 1] = sandbox[x][y].take();
-                return (x - 1, y + 1);
-            }
+
+        // Else, move 1 down and randomly left or right if able
+        let mut avail_diag_x = Vec::new();
+        if x != 0 && sandbox[x - 1][y + 1].is_none() && sandbox[x - 1][y].is_none() {
+            avail_diag_x.push(x - 1);
         }
-        // Else move 1 down and right if able
-        if x != SANDBOX_WIDTH - 1 {
-            if sandbox[x + 1][y + 1].is_none() && sandbox[x + 1][y].is_none() {
-                sandbox[x + 1][y + 1] = sandbox[x][y].take();
-                return (x + 1, y + 1);
-            }
+        if x != SANDBOX_WIDTH - 1 && sandbox[x + 1][y + 1].is_none() && sandbox[x + 1][y].is_none()
+        {
+            avail_diag_x.push(x + 1);
+        }
+        avail_diag_x.shuffle(&mut sandbox.rng);
+        if let Some(&diag_x) = avail_diag_x.get(0) {
+            sandbox[diag_x][y + 1] = sandbox[x][y].take();
+            return (diag_x, y + 1);
         }
     }
     (x, y)

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -86,34 +86,33 @@ pub fn move_gas(sandbox: &mut Sandbox, x: usize, y: usize) -> (usize, usize) {
             sandbox[x][y - 1] = sandbox[x][y].take();
             return (x, y - 1);
         }
-        // Else move 1 up and left if able
-        if x != 0 {
-            if sandbox[x - 1][y - 1].is_none() && sandbox[x - 1][y].is_none() {
-                sandbox[x - 1][y - 1] = sandbox[x][y].take();
-                return (x - 1, y - 1);
-            }
+        // Else, move 1 up and randomly left or right if able
+        let mut avail_diag_x = Vec::new();
+        if x != 0 && sandbox[x - 1][y - 1].is_none() && sandbox[x - 1][y].is_none() {
+            avail_diag_x.push(x - 1);
         }
-        // Else move 1 up and right if able
-        if x != SANDBOX_WIDTH - 1 {
-            if sandbox[x + 1][y - 1].is_none() && sandbox[x + 1][y].is_none() {
-                sandbox[x + 1][y - 1] = sandbox[x][y].take();
-                return (x + 1, y - 1);
-            }
+        if x != SANDBOX_WIDTH - 1 && sandbox[x + 1][y - 1].is_none() && sandbox[x + 1][y].is_none()
+        {
+            avail_diag_x.push(x + 1);
         }
-    }
-    // Else move left if able
-    if x != 0 {
-        if sandbox[x - 1][y].is_none() {
-            sandbox[x - 1][y] = sandbox[x][y].take();
-            return (x - 1, y);
+        avail_diag_x.shuffle(&mut sandbox.rng);
+        if let Some(&diag_x) = avail_diag_x.get(0) {
+            sandbox[diag_x][y - 1] = sandbox[x][y].take();
+            return (diag_x, y - 1);
         }
     }
-    // Else move right if able
-    if x != SANDBOX_WIDTH - 1 {
-        if sandbox[x + 1][y].is_none() {
-            sandbox[x + 1][y] = sandbox[x][y].take();
-            return (x + 1, y);
-        }
+    // Else, move randomly left or right if able
+    let mut avail_side_x = Vec::new();
+    if x != 0 && sandbox[x - 1][y].is_none() {
+        avail_side_x.push(x - 1);
+    }
+    if x != SANDBOX_WIDTH - 1 && sandbox[x + 1][y].is_none() {
+        avail_side_x.push(x + 1);
+    }
+    avail_side_x.shuffle(&mut sandbox.rng);
+    if let Some(&side_x) = avail_side_x.get(0) {
+        sandbox[side_x][y] = sandbox[x][y].take();
+        return (side_x, y);
     }
     (x, y)
 }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -10,6 +10,7 @@ fn rand_available_neighbor(
     y: usize,
     y_off: isize,
 ) -> Option<(usize, usize)> {
+    // Check whether the left and right paths to candidate cells are free
     let left = x != 0
         && (y_off == 0 || sandbox[x - 1][(y as isize + y_off) as usize].is_none())
         && sandbox[x - 1][y].is_none();
@@ -17,6 +18,7 @@ fn rand_available_neighbor(
         && (y_off == 0 || sandbox[x + 1][(y as isize + y_off) as usize].is_none())
         && sandbox[x + 1][y].is_none();
     if left || right {
+        // If both are free, pick one at random, else pick the free one
         let diag_x = if left && right {
             [x - 1, x + 1][sandbox.rng.gen::<bool>() as usize]
         } else if left {

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,6 @@
 * Freezes when tabbing out and then coming back to the game as it suddenly tries to do 1000 updates at once
 * Using shift/ctrl modifiers and moving the mouse really fast can leave gaps in particle placement
 * Electricity gets stuck with 1 particle of water in mid-air
-* Particles should move left/right randomly when they can do either
 * The UI bounding box extends a bit too far to the right
 
 ## Todo


### PR DESCRIPTION
Addresses `"Particles should move left/right randomly when they can do either"` from `todo.md`. The valid X positions for left/right particle motions are collected in a vector, which is then shuffled. If the shuffled vector is non-empty, an X position is selected and used.

This produces much more "correct" motion, especially for gasses; however, it makes it more apparent that they are randomized cellular automata. I would say that, if less "robotic" motion is desired, later changes can be made on top of this.